### PR TITLE
sc/fix/Images observation

### DIFF
--- a/Bluebird Heli/Configuration.swift
+++ b/Bluebird Heli/Configuration.swift
@@ -8,6 +8,7 @@
 
 import Foundation
 import FirebaseDatabase
+import FirebaseAuth
 
 enum Environment: String {
     
@@ -15,6 +16,9 @@ enum Environment: String {
     case Production = "production"
     
     var baseURL: DatabaseReference {
+        if Auth.auth().currentUser?.uid == "Lp1pRZPCY8QnRmpCKnPPAwslmE73" {
+            return Database.database().reference().child("staging")
+        }
         switch self {
         case .Staging: return Database.database().reference().child("staging")
         case .Production: return Database.database().reference().child("production")

--- a/Bluebird Heli/Constants.swift
+++ b/Bluebird Heli/Constants.swift
@@ -21,3 +21,10 @@ struct Colors {
     static let unavailableViewColor = UIColor(red:0.57, green:0.08, blue:0.14, alpha:1.00)
     static let standbyViewColor = UIColor(red:0.76, green:0.72, blue:0.12, alpha:1.00)
 }
+
+let sectionToReloadKey = "sectionToReloadKey"
+let itemToReloadKey = "itemToReloadKey"
+let sectionToRemoveKey = "sectionToRemoveKey"
+let itemToRemoveKey = "itemToRemoveKey"
+let sectionToAddKey = "sectionToAddKey"
+let itemToAddKey = "itemToAddKey"

--- a/Bluebird Heli/Constants.swift
+++ b/Bluebird Heli/Constants.swift
@@ -28,3 +28,8 @@ let sectionToRemoveKey = "sectionToRemoveKey"
 let itemToRemoveKey = "itemToRemoveKey"
 let sectionToAddKey = "sectionToAddKey"
 let itemToAddKey = "itemToAddKey"
+
+let mediaItemChangedNotification = Notification(name: Notification.Name(rawValue: "mediaItemChanged"), object: nil)
+let mediaItemRemovedNotification = Notification(name: Notification.Name(rawValue: "mediaItemRemoved"), object: nil)
+let mediaItemAddedNotification = Notification(name: Notification.Name(rawValue: "mediaItemAdded"), object: nil)
+

--- a/Bluebird Heli/Constants.swift
+++ b/Bluebird Heli/Constants.swift
@@ -29,7 +29,7 @@ let itemToRemoveKey = "itemToRemoveKey"
 let sectionToAddKey = "sectionToAddKey"
 let itemToAddKey = "itemToAddKey"
 
-let mediaItemChangedNotification = Notification(name: Notification.Name(rawValue: "mediaItemChanged"), object: nil)
-let mediaItemRemovedNotification = Notification(name: Notification.Name(rawValue: "mediaItemRemoved"), object: nil)
-let mediaItemAddedNotification = Notification(name: Notification.Name(rawValue: "mediaItemAdded"), object: nil)
+let mediaItemChangedNotificationName = Notification.Name(rawValue: "mediaItemChanged")
+let mediaItemRemovedNotificationName = Notification.Name(rawValue: "mediaItemRemoved")
+let mediaItemAddedNotificationName = Notification.Name(rawValue: "mediaItemAdded")
 

--- a/Bluebird Heli/Controller/FirebaseController.swift
+++ b/Bluebird Heli/Controller/FirebaseController.swift
@@ -162,7 +162,7 @@ class FirebaseController {
                             if let section = DataStore.shared.mediaSectionHeaders.index(of: dateKey), let item = arrayForSection?.index(where: {$0.date == mediaItem.date}) {
                                 UserDefaults.standard.set(section, forKey: sectionToAddKey)
                                 UserDefaults.standard.set(item, forKey: itemToAddKey)
-                                NotificationCenter.default.post(self.mediaItemAddedNotification)
+                                NotificationCenter.default.post(mediaItemAddedNotification)
                             }
                         })
                     }
@@ -178,7 +178,9 @@ class FirebaseController {
                         if let section = DataStore.shared.mediaSectionHeaders.index(of: dateKey), let item = arrayForSection?.index(where: {$0.date == mediaItem.date}) {
                             mediaArray.remove(at: item)
                             DataStore.shared.mediaDict[dateKey] = mediaArray.sorted{ $0.date < $1.date }
-                            // object removed notification
+                            UserDefaults.standard.set(section, forKey: sectionToRemoveKey)
+                            UserDefaults.standard.set(item, forKey: itemToRemoveKey)
+                            NotificationCenter.default.post(mediaItemRemovedNotification)
                         }
                     }
                 }
@@ -198,7 +200,9 @@ class FirebaseController {
                                     if let section = DataStore.shared.mediaSectionHeaders.index(of: dateKey), let item = arrayForSection?.index(where: {$0.date == mediaItem.date}) {
                                         mediaArray[item] = mediaItem
                                         DataStore.shared.mediaDict[dateKey] = mediaArray
-                                        // object changed notification
+                                        UserDefaults.standard.set(section, forKey: sectionToReloadKey)
+                                        UserDefaults.standard.set(item, forKey: itemToReloadKey)
+                                        NotificationCenter.default.post(mediaItemChangedNotification)
                                     }
                                 })
                             }

--- a/Bluebird Heli/Controller/FirebaseController.swift
+++ b/Bluebird Heli/Controller/FirebaseController.swift
@@ -179,10 +179,14 @@ class FirebaseController {
                             mediaArray.remove(at: item)
                             if mediaArray.isEmpty {
                                 DataStore.shared.mediaDict[dateKey] = nil
+                                if let dateKeyIndex = DataStore.shared.mediaSectionHeaders.index(of: dateKey) {
+                                    UserDefaults.standard.set(section, forKey: sectionToRemoveKey)
+                                    DataStore.shared.mediaSectionHeaders.remove(at: dateKeyIndex)
+                                }
                             } else {
+                                UserDefaults.standard.set(1000, forKey: sectionToRemoveKey)
                                 DataStore.shared.mediaDict[dateKey] = mediaArray.sorted{ $0.date < $1.date }
                             }
-                            UserDefaults.standard.set(section, forKey: sectionToRemoveKey)
                             UserDefaults.standard.set(item, forKey: itemToRemoveKey)
                             NotificationCenter.default.post(Notification(name: mediaItemRemovedNotificationName))
                         }

--- a/Bluebird Heli/Controller/FirebaseController.swift
+++ b/Bluebird Heli/Controller/FirebaseController.swift
@@ -13,6 +13,10 @@ import FirebaseAuth
 import FirebaseStorage
 
 class FirebaseController {
+    
+    let mediaItemChangedNotification = NSNotification(name: NSNotification.Name(rawValue: "mediaItemChanged"), object: nil)
+    let mediaItemRemovedNotification = NSNotification(name: NSNotification.Name(rawValue: "mediaItemRemoved"), object: nil)
+    let mediaItemAddedNotification = NSNotification(name: NSNotification.Name(rawValue: "mediaItemAdded"), object: nil)
    
     var baseURL: DatabaseReference {
         var configuration = Configuration()

--- a/Bluebird Heli/Controller/FirebaseController.swift
+++ b/Bluebird Heli/Controller/FirebaseController.swift
@@ -14,10 +14,6 @@ import FirebaseStorage
 
 class FirebaseController {
     
-    let mediaItemChangedNotification = NSNotification(name: NSNotification.Name(rawValue: "mediaItemChanged"), object: nil)
-    let mediaItemRemovedNotification = NSNotification(name: NSNotification.Name(rawValue: "mediaItemRemoved"), object: nil)
-    let mediaItemAddedNotification = NSNotification(name: NSNotification.Name(rawValue: "mediaItemAdded"), object: nil)
-   
     var baseURL: DatabaseReference {
         var configuration = Configuration()
         return configuration.environment.baseURL
@@ -164,9 +160,10 @@ class FirebaseController {
                             DataStore.shared.mediaDict[dateKey] = mediaArray.sorted{ $0.date < $1.date }
                             let arrayForSection = DataStore.shared.mediaDict[dateKey]
                             if let section = DataStore.shared.mediaSectionHeaders.index(of: dateKey), let item = arrayForSection?.index(where: {$0.date == mediaItem.date}) {
-                                // object added notification
+                                UserDefaults.standard.set(section, forKey: sectionToAddKey)
+                                UserDefaults.standard.set(item, forKey: itemToAddKey)
+                                NotificationCenter.default.post(self.mediaItemAddedNotification)
                             }
-                            
                         })
                     }
                 }
@@ -216,28 +213,7 @@ class FirebaseController {
         guard let uid = Auth.auth().currentUser?.uid else { print("No group uid"); return }
         baseURL.child("images").child(uid).observe(.childAdded) { (snapshot) in
             self.observeImages(for: snapshot.key)
-        //    print(snapshot.key)
-        
-            if let datesDict = snapshot.value as? [String: Any] {
-                for dateKey in datesDict.keys {
-  //                  print(dateKey)
-                }
-            }
         }
-        baseURL.child("images").child(uid).observe(.childRemoved) { (snapshot) in
-            if let datesDict = snapshot.value as? [String: Any] {
-                for dateKey in datesDict.keys {
-   //                 print(dateKey)
-                }
-            }
-        }
-//        baseURL.child("images").child(uid).observe(.value) { (snapshot) in
-//            if let datesDict = snapshot.value as? [String: Any] {
-//                for dateKey in datesDict.keys {
-//                    print(dateKey)
-//                }
-//            }
-//        }
     }
     
     func observeImages() {

--- a/Bluebird Heli/Controller/FirebaseController.swift
+++ b/Bluebird Heli/Controller/FirebaseController.swift
@@ -140,43 +140,85 @@ class FirebaseController {
         }
     }
     
-    func observeImages() {
+    func observeImageDateKeys() {
         guard let uid = Auth.auth().currentUser?.uid else { print("No group uid"); return }
-        baseURL.child("images").child(uid).observe(.value) { (snapshot) in
+        baseURL.child("images").child(uid).observe(.childAdded) { (snapshot) in
             if let datesDict = snapshot.value as? [String: Any] {
                 for dateKey in datesDict.keys {
-                    if let dateDict = datesDict[dateKey] as? [String: Any] {
-                        for timeStamp in dateDict.keys {
-                            if let imageDict = dateDict[timeStamp] as? [String: Any] {
-                                if let url = imageDict["url"] as? String {
-                                    let storageURL = Storage.storage().reference(forURL: url)
-                                    self.downloadImage(ref: storageURL, completion: { (data) in
-                                        if let timeStampDouble = Double(timeStamp) {
-                                            let mediaItem = Media(url: url, dateString: dateKey, date: timeStampDouble, type: .Image, data: data)
-                                            var mediaArray: [Media] = []
-                                            if let array = DataStore.shared.mediaDict[dateKey] {
-                                                mediaArray = array
-                                            }
-                                            mediaArray.append(mediaItem)
-                                            DataStore.shared.mediaDict[dateKey] = mediaArray
-                                            if !DataStore.shared.mediaSectionHeaders.contains(dateKey) {
-                                                DataStore.shared.mediaSectionHeaders.append(dateKey)
-                                            }
-                                            let arrayForSection = DataStore.shared.mediaDict[dateKey]
-                                            if let section = DataStore.shared.mediaSectionHeaders.index(of: dateKey), let item = arrayForSection?.index(where: {$0.date == mediaItem.date}) {
-                                                UserDefaults.standard.set(section, forKey: "sectionToUpdate")
-                                                UserDefaults.standard.set(item, forKey: "itemToUpdate")
-                                                NotificationCenter.default.post(Notification(name: Notification.Name(rawValue: "updatedMediaController")))
-                                            }
-                                        }
-                                    })
-                                }
-                            }
-                        }
-                    }
+                    print(dateKey)
                 }
             }
         }
+        baseURL.child("images").child(uid).observe(.childRemoved) { (snapshot) in
+            if let datesDict = snapshot.value as? [String: Any] {
+                for dateKey in datesDict.keys {
+                    print(dateKey)
+                }
+            }
+        }
+//        baseURL.child("images").child(uid).observe(.value) { (snapshot) in
+//            if let datesDict = snapshot.value as? [String: Any] {
+//                for dateKey in datesDict.keys {
+//                    print(dateKey)
+//                }
+//            }
+//        }
+    }
+    
+    func observeImages() {
+        observeImageDateKeys()
+       // guard let uid = Auth.auth().currentUser?.uid else { print("No group uid"); return }
+//        baseURL.child("images").child(uid).observe(.childAdded) { (snapshot) in
+//            print("added dict")
+//            print(snapshot)
+//        }
+//        baseURL.child("images").child(uid).observe(.childChanged) { (snapshot) in
+//            print("changed dict")
+//            print(snapshot)
+//        }
+//        baseURL.child("images").child(uid).observe(.childRemoved) { (snapshot) in
+//            print("removed dict")
+//            print(snapshot)
+//        }
+        
+        
+//        if let dateDict = datesDict[dateKey] as? [String: Any] {
+//            for timeStamp in dateDict.keys {
+//                if let imageDict = dateDict[timeStamp] as? [String: Any] {
+//                    if let url = imageDict["url"] as? String {
+//                        let storageURL = Storage.storage().reference(forURL: url)
+//                        self.downloadImage(ref: storageURL, completion: { (data) in
+//                            if let timeStampDouble = Double(timeStamp) {
+//                                let mediaItem = Media(url: url, dateString: dateKey, date: timeStampDouble, type: .Image, data: data)
+//                                var mediaArray: [Media] = []
+//                                if let array = DataStore.shared.mediaDict[dateKey] {
+//                                    mediaArray = array
+//                                }
+//                                mediaArray.append(mediaItem)
+//                                DataStore.shared.mediaDict[dateKey] = mediaArray
+//                                if !DataStore.shared.mediaSectionHeaders.contains(dateKey) {
+//                                    DataStore.shared.mediaSectionHeaders.append(dateKey)
+//                                }
+//                                let arrayForSection = DataStore.shared.mediaDict[dateKey]
+//                                if let section = DataStore.shared.mediaSectionHeaders.index(of: dateKey), let item = arrayForSection?.index(where: {$0.date == mediaItem.date}) {
+//                                    UserDefaults.standard.set(section, forKey: "sectionToUpdate")
+//                                    UserDefaults.standard.set(item, forKey: "itemToUpdate")
+//                                    NotificationCenter.default.post(Notification(name: Notification.Name(rawValue: "updatedMediaController")))
+//                                }
+//                            }
+//                        })
+//                    }
+//                }
+//            }
+//        }
+        
+//        baseURL.child("images").child(uid).observe(.value) { (snapshot) in
+//            if let datesDict = snapshot.value as? [String: Any] {
+//                for dateKey in datesDict.keys {
+//                    print(dateKey)
+//                }
+//            }
+//        }
     }
     
     func observeVideos() {

--- a/Bluebird Heli/Controller/FirebaseController.swift
+++ b/Bluebird Heli/Controller/FirebaseController.swift
@@ -180,13 +180,12 @@ class FirebaseController {
                             if mediaArray.isEmpty {
                                 DataStore.shared.mediaDict[dateKey] = nil
                                 if let dateKeyIndex = DataStore.shared.mediaSectionHeaders.index(of: dateKey) {
-                                    UserDefaults.standard.set(section, forKey: sectionToRemoveKey)
                                     DataStore.shared.mediaSectionHeaders.remove(at: dateKeyIndex)
                                 }
                             } else {
-                                UserDefaults.standard.set(1000, forKey: sectionToRemoveKey)
                                 DataStore.shared.mediaDict[dateKey] = mediaArray.sorted{ $0.date < $1.date }
                             }
+                            UserDefaults.standard.set(section, forKey: sectionToRemoveKey)
                             UserDefaults.standard.set(item, forKey: itemToRemoveKey)
                             NotificationCenter.default.post(Notification(name: mediaItemRemovedNotificationName))
                         }

--- a/Bluebird Heli/Controller/FirebaseController.swift
+++ b/Bluebird Heli/Controller/FirebaseController.swift
@@ -140,6 +140,11 @@ class FirebaseController {
         }
     }
     
+    func removeImageObserver(for dateKey: String) {
+        guard let uid = Auth.auth().currentUser?.uid else { print("No group uid"); return }
+        baseURL.child("images").child(uid).child(dateKey).removeAllObservers()
+    }
+    
     func observeImages(for dateKey: String) {
         guard let uid = Auth.auth().currentUser?.uid else { print("No group uid"); return }
         baseURL.child("images").child(uid).child(dateKey).observe(.childAdded) { (snapshot) in
@@ -154,6 +159,7 @@ class FirebaseController {
                                 mediaArray = array
                             }
                             mediaArray.append(mediaItem)
+                            print(mediaArray.count)
                             if !DataStore.shared.mediaSectionHeaders.contains(dateKey) {
                                 DataStore.shared.mediaSectionHeaders.append(dateKey)
                             }
@@ -179,9 +185,6 @@ class FirebaseController {
                             mediaArray.remove(at: item)
                             if mediaArray.isEmpty {
                                 DataStore.shared.mediaDict[dateKey] = nil
-                                if let dateKeyIndex = DataStore.shared.mediaSectionHeaders.index(of: dateKey) {
-                                    DataStore.shared.mediaSectionHeaders.remove(at: dateKeyIndex)
-                                }
                             } else {
                                 DataStore.shared.mediaDict[dateKey] = mediaArray.sorted{ $0.date < $1.date }
                             }
@@ -224,6 +227,9 @@ class FirebaseController {
         guard let uid = Auth.auth().currentUser?.uid else { print("No group uid"); return }
         baseURL.child("images").child(uid).observe(.childAdded) { (snapshot) in
             self.observeImages(for: snapshot.key)
+        }
+        baseURL.child("images").child(uid).observe(.childRemoved) { (snapshot) in
+            self.removeImageObserver(for: snapshot.key)
         }
     }
     

--- a/Bluebird Heli/Controller/FirebaseController.swift
+++ b/Bluebird Heli/Controller/FirebaseController.swift
@@ -162,7 +162,7 @@ class FirebaseController {
                             if let section = DataStore.shared.mediaSectionHeaders.index(of: dateKey), let item = arrayForSection?.index(where: {$0.date == mediaItem.date}) {
                                 UserDefaults.standard.set(section, forKey: sectionToAddKey)
                                 UserDefaults.standard.set(item, forKey: itemToAddKey)
-                                NotificationCenter.default.post(mediaItemAddedNotification)
+                                NotificationCenter.default.post(Notification(name: mediaItemAddedNotificationName))
                             }
                         })
                     }
@@ -180,7 +180,7 @@ class FirebaseController {
                             DataStore.shared.mediaDict[dateKey] = mediaArray.sorted{ $0.date < $1.date }
                             UserDefaults.standard.set(section, forKey: sectionToRemoveKey)
                             UserDefaults.standard.set(item, forKey: itemToRemoveKey)
-                            NotificationCenter.default.post(mediaItemRemovedNotification)
+                            NotificationCenter.default.post(Notification(name: mediaItemRemovedNotificationName))
                         }
                     }
                 }
@@ -202,7 +202,7 @@ class FirebaseController {
                                         DataStore.shared.mediaDict[dateKey] = mediaArray
                                         UserDefaults.standard.set(section, forKey: sectionToReloadKey)
                                         UserDefaults.standard.set(item, forKey: itemToReloadKey)
-                                        NotificationCenter.default.post(mediaItemChangedNotification)
+                                        NotificationCenter.default.post(Notification(name: mediaItemChangedNotificationName))
                                     }
                                 })
                             }

--- a/Bluebird Heli/Controller/FirebaseController.swift
+++ b/Bluebird Heli/Controller/FirebaseController.swift
@@ -177,7 +177,11 @@ class FirebaseController {
                         let arrayForSection = DataStore.shared.mediaDict[dateKey]
                         if let section = DataStore.shared.mediaSectionHeaders.index(of: dateKey), let item = arrayForSection?.index(where: {$0.date == mediaItem.date}) {
                             mediaArray.remove(at: item)
-                            DataStore.shared.mediaDict[dateKey] = mediaArray.sorted{ $0.date < $1.date }
+                            if mediaArray.isEmpty {
+                                DataStore.shared.mediaDict[dateKey] = nil
+                            } else {
+                                DataStore.shared.mediaDict[dateKey] = mediaArray.sorted{ $0.date < $1.date }
+                            }
                             UserDefaults.standard.set(section, forKey: sectionToRemoveKey)
                             UserDefaults.standard.set(item, forKey: itemToRemoveKey)
                             NotificationCenter.default.post(Notification(name: mediaItemRemovedNotificationName))

--- a/Bluebird Heli/View Controller/MediaViewController.swift
+++ b/Bluebird Heli/View Controller/MediaViewController.swift
@@ -16,7 +16,6 @@ class MediaViewController: UIViewController {
     
     override func viewDidLoad() {
         super.viewDidLoad()
-        print(DataStore.shared.mediaDict)
         let width = view.frame.size.width / 3
         let layout = collectionView?.collectionViewLayout as! UICollectionViewFlowLayout
         layout.sectionHeadersPinToVisibleBounds = true
@@ -29,7 +28,9 @@ class MediaViewController: UIViewController {
 
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
-        NotificationCenter.default.addObserver(self, selector: #selector(updateCollectionView), name: NSNotification.Name(rawValue: "updatedMediaController"), object: nil)
+        NotificationCenter.default.addObserver(self, selector: #selector(addItemsToCollectionView), name: mediaItemAddedNotificationName, object: nil)
+        NotificationCenter.default.addObserver(self, selector: #selector(removeItemsFromCollectionView), name: mediaItemRemovedNotificationName, object: nil)
+        NotificationCenter.default.addObserver(self, selector: #selector(reloadItemsInCollectionView), name: mediaItemChangedNotificationName, object: nil)
     }
     
     override func viewWillDisappear(_ animated: Bool) {
@@ -96,9 +97,9 @@ class MediaViewController: UIViewController {
         self.isEditing = !isEditing
     }
     
-    @objc func updateCollectionView() {
-        let item = UserDefaults.standard.integer(forKey: "itemToUpdate")
-        let sectionIndex = UserDefaults.standard.integer(forKey: "sectionToUpdate")
+    @objc func addItemsToCollectionView() {
+        let item = UserDefaults.standard.integer(forKey: itemToAddKey)
+        let sectionIndex = UserDefaults.standard.integer(forKey: sectionToAddKey)
         let indexPath = IndexPath(item: item, section: sectionIndex)
         if sectionIndex > collectionView.numberOfSections - 1 {
             collectionView.performBatchUpdates({
@@ -110,6 +111,19 @@ class MediaViewController: UIViewController {
             collectionView.insertItems(at: [indexPath])
         }
     }
+    @objc func reloadItemsInCollectionView() {
+        let item = UserDefaults.standard.integer(forKey: itemToReloadKey)
+        let sectionIndex = UserDefaults.standard.integer(forKey: sectionToReloadKey)
+        let indexPath = IndexPath(item: item, section: sectionIndex)
+        collectionView.reloadItems(at: [indexPath])
+    }
+    @objc func removeItemsFromCollectionView() {
+        let item = UserDefaults.standard.integer(forKey: itemToRemoveKey)
+        let sectionIndex = UserDefaults.standard.integer(forKey: sectionToRemoveKey)
+        let indexPath = IndexPath(item: item, section: sectionIndex)
+        collectionView.reloadItems(at: [indexPath])
+    }
+
 }
 
 // MARK: - Data Source Helper Methods

--- a/Bluebird Heli/View Controller/MediaViewController.swift
+++ b/Bluebird Heli/View Controller/MediaViewController.swift
@@ -121,7 +121,6 @@ class MediaViewController: UIViewController {
         let item = UserDefaults.standard.integer(forKey: itemToRemoveKey)
         let sectionIndex = UserDefaults.standard.integer(forKey: sectionToRemoveKey)
         let indexPath = IndexPath(item: item, section: sectionIndex)
-        print(mediaArray(for: sectionIndex).count)
         if mediaArray(for: sectionIndex).isEmpty {
             collectionView.performBatchUpdates({
                 let set = IndexSet(integer: sectionIndex)

--- a/Bluebird Heli/View Controller/MediaViewController.swift
+++ b/Bluebird Heli/View Controller/MediaViewController.swift
@@ -121,7 +121,15 @@ class MediaViewController: UIViewController {
         let item = UserDefaults.standard.integer(forKey: itemToRemoveKey)
         let sectionIndex = UserDefaults.standard.integer(forKey: sectionToRemoveKey)
         let indexPath = IndexPath(item: item, section: sectionIndex)
-        collectionView.reloadItems(at: [indexPath])
+        if sectionIndex > collectionView.numberOfSections - 1 {
+            collectionView.performBatchUpdates({
+                let set = IndexSet(integer: sectionIndex)
+                collectionView.deleteSections(set)
+                self.collectionView.deleteItems(at: [indexPath])
+            }, completion: nil)
+        } else {
+            collectionView.deleteItems(at: [indexPath])
+        }
     }
 
 }

--- a/Bluebird Heli/View Controller/MediaViewController.swift
+++ b/Bluebird Heli/View Controller/MediaViewController.swift
@@ -121,11 +121,13 @@ class MediaViewController: UIViewController {
         let item = UserDefaults.standard.integer(forKey: itemToRemoveKey)
         let sectionIndex = UserDefaults.standard.integer(forKey: sectionToRemoveKey)
         let indexPath = IndexPath(item: item, section: sectionIndex)
+        print(mediaArray(for: sectionIndex).count)
         if mediaArray(for: sectionIndex).isEmpty {
             collectionView.performBatchUpdates({
                 let set = IndexSet(integer: sectionIndex)
                 collectionView.deleteSections(set)
                 self.collectionView.deleteItems(at: [indexPath])
+                DataStore.shared.mediaSectionHeaders.remove(at: sectionIndex)
             }, completion: nil)
         } else {
             collectionView.deleteItems(at: [indexPath])

--- a/Bluebird Heli/View Controller/MediaViewController.swift
+++ b/Bluebird Heli/View Controller/MediaViewController.swift
@@ -16,6 +16,7 @@ class MediaViewController: UIViewController {
     
     override func viewDidLoad() {
         super.viewDidLoad()
+        print(DataStore.shared.mediaDict)
         let width = view.frame.size.width / 3
         let layout = collectionView?.collectionViewLayout as! UICollectionViewFlowLayout
         layout.sectionHeadersPinToVisibleBounds = true

--- a/Bluebird Heli/View Controller/MediaViewController.swift
+++ b/Bluebird Heli/View Controller/MediaViewController.swift
@@ -121,18 +121,17 @@ class MediaViewController: UIViewController {
         let item = UserDefaults.standard.integer(forKey: itemToRemoveKey)
         let sectionIndex = UserDefaults.standard.integer(forKey: sectionToRemoveKey)
         let indexPath = IndexPath(item: item, section: sectionIndex)
-        if sectionIndex == 1000 {
-            collectionView.deleteItems(at: [indexPath])
-        } else {
+        if mediaArray(for: sectionIndex).isEmpty {
             collectionView.performBatchUpdates({
                 let set = IndexSet(integer: sectionIndex)
                 collectionView.deleteSections(set)
                 self.collectionView.deleteItems(at: [indexPath])
             }, completion: nil)
+        } else {
+            collectionView.deleteItems(at: [indexPath])
         }
-        
     }
-
+    
 }
 
 // MARK: - Data Source Helper Methods

--- a/Bluebird Heli/View Controller/MediaViewController.swift
+++ b/Bluebird Heli/View Controller/MediaViewController.swift
@@ -121,15 +121,16 @@ class MediaViewController: UIViewController {
         let item = UserDefaults.standard.integer(forKey: itemToRemoveKey)
         let sectionIndex = UserDefaults.standard.integer(forKey: sectionToRemoveKey)
         let indexPath = IndexPath(item: item, section: sectionIndex)
-        if sectionIndex > collectionView.numberOfSections - 1 {
+        if sectionIndex == 1000 {
+            collectionView.deleteItems(at: [indexPath])
+        } else {
             collectionView.performBatchUpdates({
                 let set = IndexSet(integer: sectionIndex)
                 collectionView.deleteSections(set)
                 self.collectionView.deleteItems(at: [indexPath])
             }, completion: nil)
-        } else {
-            collectionView.deleteItems(at: [indexPath])
         }
+        
     }
 
 }


### PR DESCRIPTION
There were errors with image observation making it so that when one image was changed, it download and append the entire media dictionary again.
I set up notifications and methods in order to make it so images reload, delete and insert individually from the collection view without crashing or creating duplicates.